### PR TITLE
Refatoração e Expansão de Validações no Analisador Semântico

### DIFF
--- a/fontes/analisador-semantico/analisador-semantico-portugol-studio.ts
+++ b/fontes/analisador-semantico/analisador-semantico-portugol-studio.ts
@@ -113,9 +113,47 @@ export class AnalisadorSemanticoPortugolStudio extends AnalisadorSemanticoBase {
         return Promise.resolve();
     }
 
+    private validarCompatibilidadeTipos(tipoInferido: string, tipoEsperado: string): string | null {
+        switch (tipoEsperado) {
+            case tiposDeDados.CADEIA:
+                if (tipoInferido !== tiposDeDados.CARACTER) {
+                    return `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${tipoEsperado}'.`;
+                }
+                break;
+            case tiposDeDados.REAL:
+                if (tipoInferido !== tiposDeDados.INTEIRO) {
+                    return `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${tipoEsperado}'.`;
+                }
+                break;
+            default:
+                return `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${tipoEsperado}'.`;
+        }
+        return null;
+    }
+
     visitarExpressaoDeAtribuicao(expressao: Atribuir) {
         const { simbolo, valor } = expressao;
-        let variavel = this.variaveis[simbolo.lexema];
+        const variavel = this.variaveis[simbolo.lexema];
+
+        if (valor instanceof Variavel) {
+            const { simbolo: simboloVariavel } = valor;
+            const variavelExistente = this.variaveis[simboloVariavel.lexema];
+
+            if (!variavelExistente) {
+                this.adicionarDiagnostico(simboloVariavel, `Variável não declarada: ${simboloVariavel.lexema}.`);
+                return Promise.resolve();
+            }
+
+            const tipoInferido = inferirTipoVariavel(variavelExistente.valor);
+            if (tipoInferido !== variavelExistente.tipo) {
+                const erroTipo = this.validarCompatibilidadeTipos(variavelExistente.tipo, tipoInferido);
+                if (erroTipo) {
+                    this.adicionarDiagnostico(simbolo, erroTipo);
+                    return Promise.resolve();
+                }
+            }
+        }
+
         if (!variavel) {
             this.adicionarDiagnostico(simbolo, `Variável não declarada: ${simbolo.lexema}.`);
             return Promise.resolve();
@@ -126,43 +164,19 @@ export class AnalisadorSemanticoPortugolStudio extends AnalisadorSemanticoBase {
             return Promise.resolve();
         }
 
-        if (variavel.tipo) {
-            if (valor instanceof Literal) {
-                const tipoInferido = inferirTipoVariavel(valor.valor);
-                if (tipoInferido !== variavel.tipo) {
-                    switch (variavel.tipo) {
-                        case tiposDeDados.CADEIA:
-                            if (tipoInferido !== tiposDeDados.CARACTER) {
-                                this.adicionarDiagnostico(
-                                    simbolo,
-                                    `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${variavel.tipo}'.`
-                                );
-                                return Promise.resolve();
-                            }
-                            break;
-                        case tiposDeDados.REAL:
-                            if (tipoInferido !== tiposDeDados.INTEIRO) {
-                                this.adicionarDiagnostico(
-                                    simbolo,
-                                    `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${variavel.tipo}'.`
-                                );
-                                return Promise.resolve();
-                            }
-                            break;
-                        default:
-                            this.adicionarDiagnostico(
-                                simbolo,
-                                `Não é possível atribuir um valor do tipo '${tipoInferido}' a uma variável do tipo '${variavel.tipo}'.`
-                            );
-                            return Promise.resolve();
-                    }
+        if (variavel.tipo && valor instanceof Literal) {
+            const tipoInferido = inferirTipoVariavel(valor.valor);
+            if (tipoInferido !== variavel.tipo) {
+                const erroTipo = this.validarCompatibilidadeTipos(tipoInferido, variavel.tipo);
+                if (erroTipo) {
+                    this.adicionarDiagnostico(simbolo, erroTipo);
+                    return Promise.resolve();
                 }
             }
         }
 
-        if (variavel) {
-            this.variaveis[simbolo.lexema].valor = valor;
-        }
+        this.variaveis[simbolo.lexema].valor = valor;
+
     }
 
     visitarExpressaoDeChamada(expressao: Chamada): Promise<any> {
@@ -178,8 +192,7 @@ export class AnalisadorSemanticoPortugolStudio extends AnalisadorSemanticoBase {
             if (funcao.parametros.length != expressao.argumentos.length) {
                 this.adicionarDiagnostico(
                     variavel.simbolo,
-                    `Esperava ${funcao.parametros.length} ${
-                        funcao.parametros.length > 1 ? 'parâmetros' : 'parâmetro'
+                    `Esperava ${funcao.parametros.length} ${funcao.parametros.length > 1 ? 'parâmetros' : 'parâmetro'
                     }, mas foi passado ${expressao.argumentos.length}.`
                 );
             }
@@ -226,8 +239,8 @@ export class AnalisadorSemanticoPortugolStudio extends AnalisadorSemanticoBase {
     visitarExpressaoAtribuicaoPorIndice(expressao: AtribuicaoPorIndice): Promise<any> {
         const atribuir = new Atribuir(
             expressao.hashArquivo,
-            (expressao.objeto as any).simbolo, // TODO: Aqui normalmente é um literal ou identificador, mas precisa 
-                                               // ocorrer uma correta verificação do tipo.
+            (expressao.objeto as any).simbolo, // TODO: Aqui normalmente é um literal ou identificador, mas precisa
+            // ocorrer uma correta verificação do tipo.
             expressao.valor,
             expressao.indice
         );

--- a/fontes/analisador-semantico/analisador-semantico-portugol-studio.ts
+++ b/fontes/analisador-semantico/analisador-semantico-portugol-studio.ts
@@ -92,17 +92,41 @@ export class AnalisadorSemanticoPortugolStudio extends AnalisadorSemanticoBase {
     }
 
     visitarDeclaracaoVar(declaracao: Var): Promise<any> {
-        this.variaveis[declaracao.simbolo.lexema] = {
+        const { simbolo, inicializador } = declaracao;
+        if (inicializador instanceof Variavel) {
+            const { simbolo: simboloInicializador } = inicializador;
+            const variavelExistente = this.variaveis[simboloInicializador.lexema];
+
+            if (!variavelExistente) {
+                this.adicionarDiagnostico(
+                    simboloInicializador,
+                    `Variável não declarada: ${simboloInicializador.lexema}.`
+                );
+                return Promise.resolve();
+            }
+
+            const tipoInferido = inferirTipoVariavel(variavelExistente.valor);
+            if (tipoInferido !== declaracao.tipo) {
+                const erroTipo = this.validarCompatibilidadeTipos(tipoInferido, declaracao.tipo);
+                if (erroTipo) {
+                    this.adicionarDiagnostico(simbolo, erroTipo);
+                    return Promise.resolve();
+                }
+            }
+        }
+
+        this.variaveis[simbolo.lexema] = {
             imutavel: false,
             tipo: declaracao.tipo,
             valor:
-                declaracao.inicializador !== null
-                    ? declaracao.inicializador.valor !== undefined
-                        ? declaracao.inicializador.valor
-                        : declaracao.inicializador
+                inicializador !== null
+                    ? inicializador.valor !== undefined
+                        ? inicializador.valor
+                        : inicializador
                     : undefined,
             valorDefinido: true,
         };
+
         return Promise.resolve();
     }
 

--- a/testes/analisador-semantico.test.ts
+++ b/testes/analisador-semantico.test.ts
@@ -14,134 +14,202 @@ describe('Analisador sêmantico', () => {
             analisadorSemantico = new AnalisadorSemanticoPortugolStudio();
         });
 
-        it('Variável indefinida, não declarada (escreva)', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
-                '    funcao inicio()',
-                '    {',
-                '        escreva(mensagem)',
-                '    }',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
-
-
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-        });
-        it('Variável indefinida, não declarada (atribuição)', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
+        describe('Casos de Sucesso', () => {
+            it('Atribuição por indice', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa {',
                     'funcao inicio() {',
-                        'message = "olá mundo"',
+                    'inteiro numeros[10]',
+                    'numeros[1] = "5"',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
 
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-        });
-        it('Atribuição de variaveis inválida', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
+
+            it('Atribuição de variáveis válida', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
                     'funcao inicio() {',
-                        'real x',
-                        'inteiro y',
-                        'caracter a',
-                        'cadeia b',
-                        'logico l',
-                        'x = "25"',
-                        'y = "6x"',
-                        'l = 24',
-                        'b = 34',
-                        'x = 25',
-                        'y = 25.4',
+                    'real x',
+                    'inteiro y',
+                    'x = 25.4',
+                    'y = 10',
+                    'escreva(x, y)',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
 
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(5);
-            expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toEqual("Não é possível atribuir um valor do tipo 'cadeia' a uma variável do tipo 'real'.");
-            expect(retornoAnalisadorSemantico.diagnosticos[1].mensagem).toEqual("Não é possível atribuir um valor do tipo 'cadeia' a uma variável do tipo 'inteiro'.");
-            expect(retornoAnalisadorSemantico.diagnosticos[2].mensagem).toEqual("Não é possível atribuir um valor do tipo 'inteiro' a uma variável do tipo 'lógico'.");
-            expect(retornoAnalisadorSemantico.diagnosticos[3].mensagem).toEqual("Não é possível atribuir um valor do tipo 'inteiro' a uma variável do tipo 'cadeia'.");
-            expect(retornoAnalisadorSemantico.diagnosticos[4].mensagem).toEqual("Não é possível atribuir um valor do tipo 'real' a uma variável do tipo 'inteiro'.");
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(0);
+            });
+
         });
 
-        it('Atribuição por indice', () => {
-            const retornoLexador = lexador.mapear([
-                'programa {',
+        describe('Casos de Falha', () => {
+            it('Variável indefinida, não declarada (escreva)', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
+                    '    funcao inicio()',
+                    '    {',
+                    '        escreva(mensagem)',
+                    '    }',
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
+            it('Variável indefinida, não declarada (atribuição)', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
                     'funcao inicio() {',
-                      'inteiro numeros[10]',
-                      'numeros[1] = "5"',
+                    'message = "olá mundo"',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
 
-
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-        });
-        it('Chamada de função inexistente', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
+            it('Atribuição de variáveis inválida', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
                     'funcao inicio() {',
-                        'saudacao()',
+                    'real x',
+                    'inteiro y',
+                    'caracter a',
+                    'cadeia b',
+                    'logico l',
+                    'x = "25"',
+                    'y = "6x"',
+                    'l = 24',
+                    'b = 34',
+                    'x = 25',
+                    'y = 25.4',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
 
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-        });
-        it('Chamada de função com tipos de parâmetros diferentes', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(5);
+
+
+                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toEqual("Não é possível atribuir um valor do tipo 'cadeia' a uma variável do tipo 'real'.");
+                expect(retornoAnalisadorSemantico.diagnosticos[1].mensagem).toEqual("Não é possível atribuir um valor do tipo 'cadeia' a uma variável do tipo 'inteiro'.");
+                expect(retornoAnalisadorSemantico.diagnosticos[2].mensagem).toEqual("Não é possível atribuir um valor do tipo 'inteiro' a uma variável do tipo 'lógico'.");
+                expect(retornoAnalisadorSemantico.diagnosticos[3].mensagem).toEqual("Não é possível atribuir um valor do tipo 'inteiro' a uma variável do tipo 'cadeia'.");
+                expect(retornoAnalisadorSemantico.diagnosticos[4].mensagem).toEqual("Não é possível atribuir um valor do tipo 'real' a uma variável do tipo 'inteiro'.");
+            });
+
+            it('Erro ao atribuir uma variável não declarada', () => {
+                const resultado = lexador.mapear([
+                    'programa {',
+                    '    funcao inicio() {',
+                    '        inteiro b = a',
+                    '    }',
+                    '}'
+                ], -1);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(resultado, -1);
+
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe("Variável não declarada: a.");
+            });
+
+            it('Erro ao atribuir valor de tipo incompatível', () => {
+                const resultado = lexador.mapear([
+                    'programa {',
+                    '    funcao inicio() {',
+                    '        inteiro a = 2',
+                    '        cadeia b = a',
+                    '    }',
+                    '}'
+                ], -1);
+
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(resultado, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+                expect(retornoAnalisadorSemantico.diagnosticos[0].mensagem).toBe(
+                    "Não é possível atribuir um valor do tipo 'inteiro' a uma variável do tipo 'cadeia'."
+                );
+            });
+
+
+
+            it('Chamada de função inexistente', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
                     'funcao inicio() {',
-                        'saudacao(4)',
+                    'saudacao()',
+                    '}',
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
+            it('Chamada de função com tipos de parâmetros diferentes', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
+                    'funcao inicio() {',
+                    'saudacao(4)',
                     '}',
                     'funcao saudacao(cadeia message) {',
-                        'escreva(message)',
+                    'escreva(message)',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
 
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
-        });
-        it('Reatribuição de valores a uma constante', () => {
-            const retornoLexador = lexador.mapear([
-                'programa',
-                '{',
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
+            it('Reatribuição de valores a uma constante', () => {
+                const retornoLexador = lexador.mapear([
+                    'programa',
+                    '{',
                     'funcao inicio() {',
-                        'const inteiro numero = 3',
-                        'numero = 4',
+                    'const inteiro numero = 3',
+                    'numero = 4',
                     '}',
-                '}'
-            ], -1);
-            const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
-            const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
+                    '}'
+                ], -1);
+                const retornoAvaliadorSintatico = avaliadorSintatico.analisar(retornoLexador, -1);
+                const retornoAnalisadorSemantico = analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
 
-            expect(retornoAnalisadorSemantico).toBeTruthy();
-            expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+                expect(retornoAnalisadorSemantico).toBeTruthy();
+                expect(retornoAnalisadorSemantico.diagnosticos).toHaveLength(1);
+            });
         });
-
     })
 })


### PR DESCRIPTION
# PR: Refatoração e Expansão de Validações no Analisador Semântico

## Descrição
Este pull request implementa melhorias significativas no **Analisador Semântico**, abordando a resolução da issue **[#37  - Avaliador Sintático: Numa atribuição cujo valor é outra variável, verificar o tipo de valor](https://github.com/DesignLiquido/portugol-studio/issues/37)** . As alterações incluem ajustes no código principal, organização dos testes existentes e adição de novos casos para garantir maior robustez e cobertura.

---

## Mudanças Realizadas

### **1. Melhorias no Código Principal**
- **Adicionada verificação de variáveis não declaradas em declarações e atribuições**:
  - Alteração no método `visitarDeclaracaoVar` para verificar se uma variável usada como inicializador já foi declarada no escopo atual ou superior.
  - Inclusão de diagnóstico apropriado para casos de uso de variáveis não declaradas.

- **Validação de tipos em atribuições**:
  - Verificação de compatibilidade de tipos em inicializadores de variáveis, com mensagens detalhadas para tipos incompatíveis.
  - Alteração no método `visitarExpressaoDeAtribuicao` para lidar com validações mais precisas de variáveis referenciadas.

- **Reestruturação da lógica de validação de tipos**:
  - Criação do método auxiliar `validarCompatibilidadeTipos`, centralizando a lógica de validação de compatibilidade entre tipos.

### **2. Organização e Expansão dos Testes**
- **Casos de Sucesso**:
  - Testes para verificar atribuições válidas entre tipos compatíveis.
  - Teste para atribuição válida por índice em arrays.

- **Casos de Falha**:
  - Verificações para os seguintes cenários:
    - Uso de variáveis não declaradas em atribuições ou chamadas de funções.
    - Atribuições de valores com tipos incompatíveis.
    - Reatribuição de valores a constantes.
    - Chamada de funções inexistentes.
    - Argumentos com tipos incompatíveis em chamadas de funções.

---
