### PR TITLE
Corrige instrução `pare` como break em laços de repetição

### DIFF
--- a/fontes/avaliador-sintatico/avaliador-sintatico-portugol-studio.ts
+++ b/fontes/avaliador-sintatico/avaliador-sintatico-portugol-studio.ts
@@ -30,6 +30,7 @@ import {
     Retorna,
     Const,
     Comentario,
+    Sustar,
 } from '@designliquido/delegua/declaracoes';
 import { RetornoLexador, RetornoAvaliadorSintatico } from '@designliquido/delegua/interfaces/retornos';
 import { AvaliadorSintaticoBase } from '@designliquido/delegua/avaliador-sintatico/avaliador-sintatico-base';
@@ -976,6 +977,11 @@ export class AvaliadorSintaticoPortugolStudio extends AvaliadorSintaticoBase {
         return new Retorna(simboloChave, valor);
     }
 
+    declaracaoPare(): Sustar {
+        const simbolo = this.avancarEDevolverAnterior();
+        return new Sustar(simbolo);
+    }
+
     async declaracaoPara(): Promise<Para> {
         try {
             const simboloPara: SimboloInterface = this.avancarEDevolverAnterior();
@@ -1146,6 +1152,8 @@ export class AvaliadorSintaticoPortugolStudio extends AvaliadorSintaticoBase {
                 return this.declaracaoLogicos();
             case tiposDeSimbolos.PARA:
                 return await this.declaracaoPara();
+            case tiposDeSimbolos.PARE:
+                return this.declaracaoPare();
             case tiposDeSimbolos.PROGRAMA:
             case tiposDeSimbolos.CHAVE_DIREITA:
                 this.avancarEDevolverAnterior();

--- a/testes/avaliador-sintatico.test.ts
+++ b/testes/avaliador-sintatico.test.ts
@@ -313,6 +313,50 @@ describe('Avaliador sintático (Portugol Studio)', () => {
                 expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
             });
 
+            it('Estruturas de repetição - Enquanto com pare', async () => {
+                const resultado = lexador.mapear([
+                    'programa {',
+                    '    funcao inicio() {',
+                    '        inteiro i = 1',
+                    '        enquanto (i <= 10) {',
+                    '            se (i == 5) {',
+                    '                pare',
+                    '            }',
+                    '            escreva(i)',
+                    '            i++',
+                    '        }',
+                    '    }',
+                    '}'
+                ], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(resultado, -1);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
+            });
+
+            it('Estruturas de repetição - Faca...Enquanto com pare', async () => {
+                const resultado = lexador.mapear([
+                    'programa {',
+                    '    funcao inicio() {',
+                    '        inteiro i = 1',
+                    '        faca {',
+                    '            se (i == 5) {',
+                    '                pare',
+                    '            }',
+                    '            escreva(i)',
+                    '            i++',
+                    '        } enquanto (i <= 10)',
+                    '    }',
+                    '}'
+                ], -1);
+
+                const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(resultado, -1);
+
+                expect(retornoAvaliadorSintatico).toBeTruthy();
+                expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
+            });
+
             describe('Estruturas de repetição - Para', () => {
                 it('Trivial', async () => {
                     const resultado = lexador.mapear([
@@ -324,9 +368,9 @@ describe('Avaliador sintático (Portugol Studio)', () => {
                         '    }',
                         '  }'
                     ], -1);
-    
+
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(resultado, -1);
-    
+
                     expect(retornoAvaliadorSintatico).toBeTruthy();
                     expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
                 });
@@ -346,9 +390,29 @@ describe('Avaliador sintático (Portugol Studio)', () => {
                         '	}',
                         '}'
                         ], -1);
-    
+
                     const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(resultado, -1);
-    
+
+                    expect(retornoAvaliadorSintatico).toBeTruthy();
+                    expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
+                });
+
+                it('Com pare para sair do loop', async () => {
+                    const resultado = lexador.mapear([
+                        'programa {',
+                        '    funcao inicio() {',
+                        '        para (inteiro i = 1; i <= 10; i++) {',
+                        '            se (i == 5) {',
+                        '                pare',
+                        '            }',
+                        '            escreva(i)',
+                        '        }',
+                        '    }',
+                        '}'
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(resultado, -1);
+
                     expect(retornoAvaliadorSintatico).toBeTruthy();
                     expect(retornoAvaliadorSintatico.declaracoes.length).toBe(2);
                 });

--- a/testes/interpretador.test.ts
+++ b/testes/interpretador.test.ts
@@ -73,6 +73,64 @@ describe('Interpretador (Portugol Studio)', () => {
                     expect(retornoInterpretador.erros).toHaveLength(0);
                     expect(_saidas).toHaveLength(10);
                 });
+
+                it('Com pare: deve parar antes de chegar ao fim', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'programa {',
+                        '    funcao inicio() {',
+                        '        para (inteiro i = 1; i <= 10; i++) {',
+                        '            se (i == 5) {',
+                        '                pare',
+                        '            }',
+                        '            escreva(i)',
+                        '        }',
+                        '    }',
+                        '}'
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetornoMesmaLinha = (saida: string) => {
+                        _saidas.push(saida);
+                    }
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(4);
+                    expect(_saidas).toEqual(['1 ', '2 ', '3 ', '4 ']);
+                });
+            })
+
+            describe('Enquanto', () => {
+                it('Com pare: deve parar antes de chegar ao fim', async () => {
+                    const retornoLexador = lexador.mapear([
+                        'programa {',
+                        '    funcao inicio() {',
+                        '        inteiro i = 1',
+                        '        enquanto (i <= 10) {',
+                        '            se (i == 5) {',
+                        '                pare',
+                        '            }',
+                        '            escreva(i)',
+                        '            i++',
+                        '        }',
+                        '    }',
+                        '}'
+                    ], -1);
+
+                    const retornoAvaliadorSintatico = await avaliadorSintatico.analisar(retornoLexador, -1);
+
+                    interpretador.funcaoDeRetornoMesmaLinha = (saida: string) => {
+                        _saidas.push(saida);
+                    }
+
+                    const retornoInterpretador = await interpretador.interpretar(retornoAvaliadorSintatico.declaracoes);
+
+                    expect(retornoInterpretador.erros).toHaveLength(0);
+                    expect(_saidas).toHaveLength(4);
+                    expect(_saidas).toEqual(['1 ', '2 ', '3 ', '4 ']);
+                });
             })
 
             describe('Leia', () => {


### PR DESCRIPTION
## Problema

A palavra reservada `pare` já existia no lexador e era mapeada corretamente para o token `PARE`, mas o avaliador sintático só a reconhecia dentro de blocos `escolha`/`caso`. Quando `pare` aparecia como instrução autônoma dentro de um laço (`para`, `enquanto`, `faca`), o avaliador caía no `default` de `resolverDeclaracaoForaDeBloco` e tentava parsear o token como expressão, lançando erro:

`erro: token 'pare' não reconhecido como expressão`


O comportamento esperado, conforme o Portugol Studio original, é que `pare` interrompa o laço imediatamente, equivalente ao `break` em outras linguagens.

## Portugol Studio (https://portugol.dev/)

<img width="1908" height="918" alt="image" src="https://github.com/user-attachments/assets/878274ea-f8c8-4a66-a873-1ed7a1ca86f6" />

## Solução

Esta correção adiciona o método `declaracaoPare()` no avaliador sintático, que consome o token e retorna um nó `Sustar` — a representação semântica de break já existente no Delégua. O `case tiposDeSimbolos.PARE` é registrado no switch de `resolverDeclaracaoForaDeBloco`, tornando `pare` válido em qualquer contexto de laço.

O comportamento do `pare` dentro de `escolha`/`caso` permanece inalterado, pois lá o token é consumido diretamente por `verificarSeSimboloAtualEIgualA` antes de chegar ao switch.

## Testes adicionados

- Avaliador sintático: `pare` dentro de `para`, `enquanto` e `faca`
- Interpretador: verificação de que o loop interrompe na iteração correta (`para` e `enquanto`)

